### PR TITLE
Fix issues with loading children after an async search

### DIFF
--- a/docs/components/AsyncSearching.vue
+++ b/docs/components/AsyncSearching.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-  import { ASYNC_SEARCH } from '@riophae/vue-treeselect'
+  import { ASYNC_SEARCH, LOAD_CHILDREN_OPTIONS } from '@riophae/vue-treeselect'
 
   const simulateAsyncOperation = fn => {
     setTimeout(fn, 2000)
@@ -15,14 +15,23 @@
 
   export default {
     methods: {
-      loadOptions({ action, searchQuery, callback }) {
+      loadOptions({ action, searchQuery, parentNode, callback }) {
         if (action === ASYNC_SEARCH) {
           simulateAsyncOperation(() => {
             const options = [ 1, 2, 3, 4, 5 ].map(i => ({
               id: `${searchQuery}-${i}`,
               label: `${searchQuery}-${i}`,
+              children: null,
             }))
             callback(null, options)
+          })
+        } else if (action === LOAD_CHILDREN_OPTIONS) {
+          simulateAsyncOperation(() => {
+            parentNode.children = [ {
+              id: `${parentNode.id}-child`,
+              label: `${parentNode.label} child`,
+            } ]
+            callback()
           })
         }
       },

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -1680,6 +1680,12 @@ export default {
       // So `parentNode` can be stale and we use `getNode()` to avoid that.
 
       const { id, raw } = parentNode
+      const done = () => {
+        if (this.async) {
+          this.initialize()
+          this.resetHighlightedOptionWhenNecessary(true)
+        }
+      }
 
       this.callLoadOptionsProp({
         action: LOAD_CHILDREN_OPTIONS,
@@ -1699,6 +1705,7 @@ export default {
         },
         succeed: () => {
           this.getNode(id).childrenStates.isLoaded = true
+          done()
         },
         fail: err => {
           this.getNode(id).childrenStates.loadingError = getErrorMessage(err)


### PR DESCRIPTION
If you use the component in async search mode, dynamically loading child nodes fails to display any results unless you search for something else and then go back to a previous search. Here's an example:

![2018-08-08_14-44-00](https://user-images.githubusercontent.com/1619746/43866410-73df9536-9b1a-11e8-9540-98155ec494e2.gif)

You can see it displays "no sub-options" the first time the search results appear.

This pull request changes the docs to demonstrate the issue, and modifies the code in an attempt to fix it. I'm not sure if this is the best way to fix this problem, but it does seem to work.

Here's the behavior after the fix is applied:

![2018-08-08_14-42-56](https://user-images.githubusercontent.com/1619746/43866445-99072d7e-9b1a-11e8-981f-971a608191ee.gif)

With this fix the child nodes appear immediately after the initial search and expand.