### PR TITLE
Disable ancestors on search

### DIFF
--- a/docs/components/DisableAncestorsOnSearch.vue
+++ b/docs/components/DisableAncestorsOnSearch.vue
@@ -1,0 +1,18 @@
+<template>
+  <treeselect
+    :options="options"
+    :disable-ancestors-on-search="true"
+    :multiple="true"
+    placeholder="Where are you from?"
+    />
+</template>
+
+<script>
+  import countries from './data/countries-of-the-world'
+
+  export default {
+    data: () => ({
+      options: countries,
+    }),
+  }
+</script>

--- a/docs/components/DocProps.vue
+++ b/docs/components/DocProps.vue
@@ -151,6 +151,11 @@
         defaultValue: code('","'),
         description: `Delimiter to use to join multiple values for the hidden field value.`,
       }, {
+        name: 'disableAncestorsOnSearch',
+        type: 'Boolean',
+        defaultValue: code('false'),
+        description: `Whether to flatten the tree when searching. See ${link('#disable-ancestors-on-search')} for example.`,
+      }, {
         name: 'disableBranchNodes',
         type: 'Boolean',
         defaultValue: code('false'),

--- a/docs/partials/guides.pug
+++ b/docs/partials/guides.pug
@@ -89,6 +89,11 @@
     Set `disableBranchNodes: true` to make branch nodes uncheckable and treat them as collapsible folders only. You may also want to show a count next to the label of each branch node by setting `showCount: true`.
   +demo('DisableBranchNodes')
 
++subsection('Disable Ancestors On Search')
+  :markdown-it
+    Set `disableAncestorsOnSearch: true` to flatten the tree when searching. With this option set to `true`, only the results that match will be shown. With this set to `false` (default), its ancestors will also be displayed, even if they would not individually be included in the results.
+  +demo('DisableAncestorsOnSearch')
+
 +subsection('Disable Item Selection')
   :markdown-it
     You can disable item selection by setting `isDisabled: true` on any leaf node or branch node. For non-flat mode, setting on a branch node will disable all its descendants as well.

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -37,6 +37,10 @@
           'vue-treeselect__option--hide': !instance.shouldShowOptionInMenu(node),
         }
 
+        if (instance.disableAncestorsOnSearch && instance.localSearch.active && !node.isMatched) {
+          return null
+        }
+
         return (
           <div class={optionClass} onMouseenter={this.handleMouseEnterOption} data-id={node.id}>
             {this.renderArrow()}

--- a/src/components/Treeselect.vue
+++ b/src/components/Treeselect.vue
@@ -19,10 +19,12 @@
           'vue-treeselect--disabled': this.disabled,
           'vue-treeselect--focused': this.trigger.isFocused,
           'vue-treeselect--has-value': this.hasValue,
+          'vue-treeselect--is-searching': this.trigger.searchQuery.length > 0,
           'vue-treeselect--open': this.menu.isOpen,
           'vue-treeselect--open-above': this.menu.placement === 'top',
           'vue-treeselect--open-below': this.menu.placement === 'bottom',
           'vue-treeselect--branch-nodes-disabled': this.disableBranchNodes,
+          'vue-treeselect--search-ancestors-disabled': this.disableAncestorsOnSearch,
           'vue-treeselect--append-to-body': this.appendToBody,
         }
       },

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -279,6 +279,16 @@ export default {
     },
 
     /**
+     * Only show the nodes that match the search value directly, excluding its ancestors.
+     *
+     * @type {Object}
+     */
+    disableAncestorsOnSearch: {
+      type: Boolean,
+      default: false,
+    },
+
+    /**
      * Prevent branch nodes from being selected?
      */
     disableBranchNodes: {
@@ -1358,7 +1368,7 @@ export default {
       // 1) This option is matched.
       if (node.isMatched) return true
       // 2) This option is not matched, but has matched descendant(s).
-      if (node.isBranch && node.hasMatchedDescendants) return true
+      if (!this.disableAncestorsOnSearch && node.isBranch && node.hasMatchedDescendants) return true
       // 3) This option's parent has no matched descendants,
       //    but after being expanded, all its children should be shown.
       if (!node.isRootNode && node.parentNode.showAllChildrenOnSearch) return true

--- a/src/style.less
+++ b/src/style.less
@@ -727,6 +727,18 @@
     .vue-treeselect__tip {
       padding-left: @treeselect-padding + (@i + 1) * @treeselect-narrow-cell-width;
     }
+
+    // If disable-ancestors-on-search is enabled, flatten the indentation.
+    .vue-treeselect__option,
+    .vue-treeselect__tip {
+      .vue-treeselect--is-searching.vue-treeselect--search-ancestors-disabled & {
+        padding-left: @treeselect-padding;
+        .vue-treeselect__option-arrow-placeholder,
+        .vue-treeselect__option-arrow-container {
+          display: none;
+        }
+      }
+    }
   }
 }
 .generate-level-indentations(@treeselect-max-level);


### PR DESCRIPTION
Hello!

I've been using `vue-treeselect` for a project recently, and it's really helped us out hugely. However, there are a few things that are missing for our particular use case and cause some UX issues.

The first of these issues, and the subject of this PR, is that when you search for a deep descendant within the tree, it displays all of the ancestors of the node, even if those ancestors themselves don't match what you're searching. This creates a huge amount of visual noise. For example, searching `lon` would hopefully return just `London` and `Barcelona`, but instead will show `Europe` and `United Kingdom` and `Spain`. Although this may be useful in some situations, we felt like it would confuse users.

This PR will show just the nodes that match the query if `:disable-ancestors-on-search="true"` is defined on the element. It will also add a class to the root element if this value is set.

Another small addition which is maybe not _entirely_ coupled to the PR is to add a `vue-treeselect--is-searching` class when any value is entered into the input field.

I'm fairly new to this project and completely new to its source, so winging it somewhat with how best to modify the code, naming conventions, and whether this kind of feature PR is even welcome.

Let me know how it all looks and I'll try and make any amends if it's decided this would be a good feature.

Thanks!
Matt