### PR TITLE
Don't try to select if there is no selection

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -136,6 +136,7 @@
         case KEY_CODES.ENTER: {
           evt.preventDefault()
           const current = instance.getNode(instance.menu.current)
+          if (!current) return
           if (current.isBranch && instance.disableBranchNodes) return
           instance.select(current)
           break


### PR DESCRIPTION
Avoids the error:

    Uncaught TypeError: Cannot read property 'isBranch' of null


This can happen if the treeselect is empty, and the user presses enter with the treeselect open.