### PR TITLE
Use same `options` when removing `scroll` and `resize` event listeners as when adding them

### DIFF
--- a/src/utils/setupResizeAndScrollEventListeners.js
+++ b/src/utils/setupResizeAndScrollEventListeners.js
@@ -26,9 +26,9 @@ export function setupResizeAndScrollEventListeners($el, listener) {
   })
 
   return function removeEventListeners() {
-    window.removeEventListener('resize', listener)
+    window.removeEventListener('resize', listener, { passive: true })
     $scrollParents.forEach($scrollParent => {
-      $scrollParent.removeEventListener('scroll', listener)
+      $scrollParent.removeEventListener('scroll', listener, { passive: true })
     })
   }
 }


### PR DESCRIPTION
We've recently come across a bug with Internet Explorer 11 - namely, that the `scroll` and `resize` event listeners aren't being removed. In combination with `alwaysOpen`, this is causing

```Unable to get property '$refs' of undefined or null referenceFile: vue-treeselect.js, Line: 1479, Column: 7```

A full reproduduction case can be found [here](https://github.com/sxn/treeselect-ie11-bug), and it can be seen in action [here](https://sxn.github.io/treeselect-ie11-bug/).

The fix [seems to be](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal) changing the `removeEventListener` call to pass `{ passive: true }`, i.e. the same options that were passed when calling `addEventListener`?