### PR TITLE
Added customClass attribute to node using which value-labels styles can be customized

### DIFF
--- a/docs/components/CustomizeValueLabel.vue
+++ b/docs/components/CustomizeValueLabel.vue
@@ -14,11 +14,76 @@
     data: () => ({
       multiple: true,
       value: null,
-      options: [ 1, 2, 3 ].map(i => ({
-        id: i,
-        label: `Label ${i}`,
-        customLabel: `Custom Label ${i}`,
-      })),
+      options: [ {
+        id: 'fruits',
+        label: 'Fruits with custom colors',
+        customLabel: 'Fruits 🍎 🍇 🍐 🍓 🍉', 
+        customClass: 'fruit-yellow',
+        children: [ {
+          id: 'apple',
+          label: 'Apple 🍎',
+          customLabel:'🍎',
+          customClass: 'fruit-red',
+        }, {
+          id: 'grapes',
+          customClass: 'fruit-green',
+          label: 'Grapes 🍇',
+          customLabel:'🍇',
+        }, {
+          id: 'pear',
+          customClass: 'fruit-yellow',
+          label: 'Pear 🍐',
+          customLabel:'🍐',
+        }, {
+          id: 'strawberry',
+          customClass: 'fruit-red',
+          label: 'Strawberry 🍓',
+          customLabel:'🍓',
+        }, {
+          id: 'watermelon',
+          customClass: 'fruit-green',
+          label: 'Watermelon 🍉',
+          customLabel:'🍉',
+        } ],
+      }, {
+        id: 'vegetables',
+        label: 'Vegetables',
+        customLabel: 'Vegetables 🌽🥕🍆🍅',
+        children: [ {
+          id: 'corn',
+          label: 'Corn 🌽',
+          customLabel:'🌽'
+        }, {
+          id: 'carrot',
+          label: 'Carrot 🥕',
+          customLabel:'🥕'
+        }, {
+          id: 'eggplant',
+          label: 'Eggplant 🍆',
+          customLabel:'🍆'
+        }, {
+          id: 'tomato',
+          label: 'Tomato 🍅',
+          customLabel:'🍅'
+        } ],
+      } ],
     }),
   }
 </script>
+
+
+<style lang="less">
+.fruit-yellow{
+  background-color: yellow;
+  color: black;
+}
+.fruit-red{
+background-color: red;
+color: white;
+}
+.fruit-green{
+background-color: green;
+color: white;
+}
+</style>
+

--- a/docs/components/DocNode.vue
+++ b/docs/components/DocNode.vue
@@ -36,6 +36,11 @@
           <td>Used for giving new nodes a different color.</td>
         </tr>
         <tr>
+          <td><strong>customClass</strong></td>
+          <td class="type">Boolean</td>
+          <td>Can be utilized to give new styles to value labels.</td>
+        </tr>
+        <tr>
           <td><strong>isDefaultExpanded</strong></td>
           <td class="type">Boolean</td>
           <td>Whether this folder option should be expanded by default.</td>

--- a/src/components/MultiValueItem.vue
+++ b/src/components/MultiValueItem.vue
@@ -23,14 +23,14 @@
     },
 
     render() {
-      const { instance, node } = this
-      const customClass = node.raw && node.raw.customClass;
-      const itemClass = {
+        const { instance, node } = this
+        const customClass = node.customClass;
+        const itemClass = {
         'vue-treeselect__multi-value-item': true,
         'vue-treeselect__multi-value-item-disabled': node.isDisabled,
         'vue-treeselect__multi-value-item-new': node.isNew,
-        [customClass]: customClass
-      }
+            [customClass]: !!customClass
+        }
       const customValueLabelRenderer = instance.$scopedSlots['value-label']
       const labelRenderer = customValueLabelRenderer ? customValueLabelRenderer({ node }) : node.label
 

--- a/src/components/MultiValueItem.vue
+++ b/src/components/MultiValueItem.vue
@@ -24,10 +24,12 @@
 
     render() {
       const { instance, node } = this
+      const customClass = node.raw && node.raw.customClass;
       const itemClass = {
         'vue-treeselect__multi-value-item': true,
         'vue-treeselect__multi-value-item-disabled': node.isDisabled,
         'vue-treeselect__multi-value-item-new': node.isNew,
+        [customClass]: customClass
       }
       const customValueLabelRenderer = instance.$scopedSlots['value-label']
       const labelRenderer = customValueLabelRenderer ? customValueLabelRenderer({ node }) : node.label

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -997,6 +997,7 @@ export default {
         isBranch: false,
         isDisabled: false,
         isNew: false,
+        customClass: '',
         index: [ -1 ],
         level: 0,
         raw,
@@ -1533,6 +1534,7 @@ export default {
           const isLeaf = !isBranch
           const isDisabled = !!node.isDisabled || (!this.flat && !isRootNode && parentNode.isDisabled)
           const isNew = !!node.isNew
+          const customClass = node.customClass || ''
           const lowerCased = this.matchKeys.reduce((prev, key) => ({
             ...prev,
             [key]: stringifyOptionPropValue(node[key]).toLocaleLowerCase(),
@@ -1552,6 +1554,7 @@ export default {
           this.$set(normalized, 'nestedSearchLabel', nestedSearchLabel)
           this.$set(normalized, 'isDisabled', isDisabled)
           this.$set(normalized, 'isNew', isNew)
+          this.$set(normalized, 'customClass', customClass)
           this.$set(normalized, 'isMatched', false)
           this.$set(normalized, 'isHighlighted', false)
           this.$set(normalized, 'isBranch', isBranch)

--- a/test/unit/specs/Basic.spec.js
+++ b/test/unit/specs/Basic.spec.js
@@ -51,6 +51,7 @@ describe('Basic', () => {
         isHighlighted: jasmine.any(Boolean),
         isDisabled: jasmine.any(Boolean),
         isNew: jasmine.any(Boolean),
+        customClass: jasmine.any(String),
         parentNode: jasmine.any(Object),
         ancestors: jasmine.any(Array),
         index: jasmine.any(Array),
@@ -550,6 +551,7 @@ describe('Basic', () => {
         isBranch: false,
         isDisabled: false,
         isNew: false,
+        customClass: '',
         index: [ -1 ],
         level: 0,
         raw: {


### PR DESCRIPTION
I came across requirement of having customizable different colors for each value-label in multiselect.   

Currently the value-label slot allows to change the label but the background color and other styles are defined from the parent of that slot.  


This configuration will allow developers to add custom styles to value-labels in the node attributes itself.

You can define the styles for value-label in any CSS classes then
You can apply the styles by assigning those class values in **customClass** key in any node

**Note:** This is an optional attribute, not providing this value in any node will follow the default styles

```
.....
 options: [ {
        id: 'fruits',
        label: 'Fruits with custom colors',
        customLabel: 'Fruits 🍎 🍇 🍐 🍓 🍉', 
        customClass: 'fruit-yellow',
        children: [ {
          id: 'apple',
          label: 'Apple 🍎',
          customLabel:'🍎',
          customClass: 'fruit-red',
        }, {
          id: 'grapes',
          label: 'Grapes 🍇',
          customLabel:'🍇',
          customClass: 'fruit-green',
        } ]
      } ]
.....

<style lang="less">
	.fruit-yellow {
		background-color: yellow;
		color: black;
	}
	
	.fruit-red {
		background-color: red;
		color: white;
	}
	
	.fruit-green {
		background-color: green;
		color: white;
	}
</style>

.....
```
------

## [Preview](https://user-images.githubusercontent.com/18364171/62407855-d4416980-b5dc-11e9-8524-07f69440d56a.gif)
![customize-value-label-style](https://user-images.githubusercontent.com/18364171/62407855-d4416980-b5dc-11e9-8524-07f69440d56a.gif)
