### PR TITLE
Add aria-label parameter

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -254,6 +254,7 @@
           <input ref="input"
             class="vue-treeselect__input"
             type="text"
+            aria-label={instance.ariaLabel}
             autocomplete="off"
             tabIndex={instance.tabIndex}
             required={instance.required && !instance.hasValue}

--- a/src/mixins/treeselectMixin.js
+++ b/src/mixins/treeselectMixin.js
@@ -104,6 +104,14 @@ export default {
     },
 
     /**
+     * Set the value for aria-label.
+     */
+    ariaLabel: {
+      type: String,
+      default: 'treeselect',
+    },
+
+    /**
      * Whether to enable async search mode.
      */
     async: {


### PR DESCRIPTION
Reporters like axe complain about treeselect component's `input` missing a11y parameters.
This adds an additional (optional) parameter to set the `aria-label` value for the `input` tag.