### PR TITLE
Adding slot for arrow icon

### DIFF
--- a/docs/components/DocSlots.vue
+++ b/docs/components/DocSlots.vue
@@ -38,6 +38,10 @@
         name: 'after-list',
         props: '-',
         description: `Slot showed after the menu list.`,
+      }, {
+        name: 'arrow-icon',
+        props: '-',
+        description: `Slot for a custom arrow icon.`,
       } ],
     }),
   }

--- a/src/components/Control.vue
+++ b/src/components/Control.vue
@@ -68,18 +68,31 @@
         )
       },
 
-      renderArrow() {
+      getArrow() {
         const { instance } = this
+        const arrowIconRenderer = instance.$scopedSlots['arrow-icon']
+
         const arrowClass = {
           'vue-treeselect__control-arrow': true,
           'vue-treeselect__control-arrow--rotated': instance.menu.isOpen,
+          'vue-treeselect__control-arrow--custom': arrowIconRenderer,
         }
 
+        if (arrowIconRenderer) {
+          return (
+            <div class={arrowClass}> { arrowIconRenderer() }</div>
+           )
+        }
+
+        return <ArrowIcon class={arrowClass} />
+      },
+
+      renderArrow() {
         if (!this.shouldShowArrow) return null
 
         return (
           <div class="vue-treeselect__control-arrow-container" onMousedown={this.handleMouseDownOnArrow}>
-            <ArrowIcon class={arrowClass} />
+            { this.getArrow() }
           </div>
         )
       },

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -69,6 +69,25 @@
         )
       },
 
+      getArrow() {
+        const { instance } = this
+        const arrowIconRenderer = instance.$scopedSlots['arrow-icon']
+
+        const arrowClass = {
+          'vue-treeselect__option-arrow': true,
+          'vue-treeselect__option-arrow--rotated': this.shouldExpand,
+          'vue-treeselect__option-arrow--custom': arrowIconRenderer,
+        }
+
+        if (arrowIconRenderer) {
+          return (
+            <div class={arrowClass}> { arrowIconRenderer() }</div>
+           )
+        }
+
+        return <ArrowIcon class={arrowClass} />
+      },
+
       renderArrow() {
         const { instance, node } = this
 
@@ -81,15 +100,11 @@
               appear: true,
             },
           }
-          const arrowClass = {
-            'vue-treeselect__option-arrow': true,
-            'vue-treeselect__option-arrow--rotated': this.shouldExpand,
-          }
 
           return (
             <div class="vue-treeselect__option-arrow-container" onMousedown={this.handleMouseDownOnArrow}>
               <transition {...transitionProps}>
-                <ArrowIcon class={arrowClass} />
+                { this.getArrow() }
               </transition>
             </div>
           )

--- a/src/style.less
+++ b/src/style.less
@@ -686,10 +686,6 @@
   }
 }
 
-.vue-treeselect__control-arrow--custom {
-  height: unset;
-}
-
 .vue-treeselect__control-arrow--rotated {
   transform: rotateZ(180deg);
 }

--- a/src/style.less
+++ b/src/style.less
@@ -686,6 +686,10 @@
   }
 }
 
+.vue-treeselect__control-arrow--custom {
+  height: unset;
+}
+
 .vue-treeselect__control-arrow--rotated {
   transform: rotateZ(180deg);
 }


### PR DESCRIPTION
Will give the flexibility to change the arrow icon of the select box (many design teams ask for it) closing issue #322

adding a custom slot names arrow-icon to the main arrow.
also adding same logic to the children arrows